### PR TITLE
Do not set reset link as active if any active categories are selected.

### DIFF
--- a/modules/ModuleNewsCategories.php
+++ b/modules/ModuleNewsCategories.php
@@ -189,7 +189,7 @@ class ModuleNewsCategories extends \ModuleNews
 
             $arrCategories[] = array
             (
-                'isActive' => $blnActive,
+                'isActive' => empty($this->activeNewsCategories) && $blnActive,
                 'subitems' => '',
                 'class' => 'reset first' . (($total == 1) ? ' last' : '') . ' even' . ($blnActive ? ' active' : ''),
                 'title' => specialchars($GLOBALS['TL_LANG']['MSC']['resetCategories'][1]),


### PR DESCRIPTION
If i use the news categories module on a reader page the reset link is always active even then some categories are active. This PR fixes it.