### PR TITLE
decode URL before sprintf

### DIFF
--- a/modules/ModuleNewsCategories.php
+++ b/modules/ModuleNewsCategories.php
@@ -225,7 +225,7 @@ class ModuleNewsCategories extends \ModuleNews
             $arrRow['title'] = specialchars($strTitle, true);
             $arrRow['linkTitle'] = specialchars($strTitle, true);
             $arrRow['link'] = $strTitle;
-            $arrRow['href'] = ampersand(sprintf($strUrl, ($GLOBALS['TL_CONFIG']['disableAlias'] ? $objCategories->id : $objCategories->alias)));
+            $arrRow['href'] = ampersand(sprintf(urldecode($strUrl), ($GLOBALS['TL_CONFIG']['disableAlias'] ? $objCategories->id : $objCategories->alias)));
             $arrRow['quantity'] = 0;
 
             // Get the news quantity


### PR DESCRIPTION
In Contao 4 you can have page aliases with Umlauts and other symbols. However, these will arrive encoded in `ModuleNewsCategories::renderNewsCategories` which will result in
```
ContextErrorException

Warning: sprintf(): Too few arguments
```
e.g.
```php
sprintf('de/trainings%C3%BCberblick/category/%s.html', …);
```
Simplest solution seems to be to decode the url before running sprintf on it. Not sure if that's the best one.