### PR TITLE
add leading space to css classes

### DIFF
--- a/src/EventListener/TemplateListener.php
+++ b/src/EventListener/TemplateListener.php
@@ -97,7 +97,10 @@ class TemplateListener implements FrameworkAwareInterface
 
         $template->categories = $data;
         $template->categoriesList = $list;
-        $template->class = \implode(' ', \array_unique($cssClasses));
+
+        if ($cssClasses = \array_unique($cssClasses)) {
+            $template->class = ' ' . \implode(' ', $cssClasses);
+        }
     }
 
     /**

--- a/src/EventListener/TemplateListener.php
+++ b/src/EventListener/TemplateListener.php
@@ -98,7 +98,7 @@ class TemplateListener implements FrameworkAwareInterface
         $template->categories = $data;
         $template->categoriesList = $list;
 
-        if ($cssClasses = \array_unique($cssClasses)) {
+        if (count($cssClasses = \array_unique($cssClasses)) > 0) {
             $template->class = ' ' . \implode(' ', $cssClasses);
         }
     }


### PR DESCRIPTION
You need to add a leading space to the css classes, otherwise you'll end up with
```
class="layout_full blocknews_category_3 category_3 news_category_6 category_6"
```
instead of 
```
class="layout_full block news_category_3 category_3 news_category_6 category_6"
```
The `contao/news-bundle` also always adds a leading space in its methods.