### PR TITLE
add support for news order

### DIFF
--- a/src/Criteria/NewsCriteriaBuilder.php
+++ b/src/Criteria/NewsCriteriaBuilder.php
@@ -62,7 +62,7 @@ class NewsCriteriaBuilder implements FrameworkAwareInterface
         $criteria = new NewsCriteria($this->framework);
 
         try {
-            $criteria->setBasicCriteria($archives);
+            $criteria->setBasicCriteria($archives, $module);
 
             // Set the time frame
             $criteria->setTimeFrame($begin, $end);
@@ -90,7 +90,7 @@ class NewsCriteriaBuilder implements FrameworkAwareInterface
         $criteria = new NewsCriteria($this->framework);
 
         try {
-            $criteria->setBasicCriteria($archives);
+            $criteria->setBasicCriteria($archives, $module);
 
             // Set the featured filter
             if (null !== $featured) {
@@ -124,7 +124,7 @@ class NewsCriteriaBuilder implements FrameworkAwareInterface
         $criteria = new NewsCriteria($this->framework);
 
         try {
-            $criteria->setBasicCriteria($archives);
+            $criteria->setBasicCriteria($archives, $module);
 
             // Set the regular list criteria
             $this->setRegularListCriteria($criteria, $module);


### PR DESCRIPTION
Contao 4.5 added support for sorting the news list (and news archive) in various ways (see https://github.com/contao/news-bundle/pull/13). Currently this setting is ignored when `news_categories` is in use.