### PR TITLE
use order_date_asc in Contao 4.5+

### DIFF
--- a/src/FrontendModule/NewsMenuModule.php
+++ b/src/FrontendModule/NewsMenuModule.php
@@ -27,6 +27,9 @@ class NewsMenuModule extends ModuleNewsMenu
     {
         $this->strUrl = $this->generateCategoryUrl();
 
+        // In Contao 4.5+ the value is now 'order_date_asc' instead of 'ascending'
+        $this->news_order = $this->news_order == 'order_date_asc' ? 'ascending' : $this->news_order;
+
         parent::compile();
     }
 


### PR DESCRIPTION
In Contao 4.5, the values for `news_order` have changed (see also #128). Currently if you have the news_categories extension installed, the yearly news archive menu configuration _Date (ascending)_ has no effect.