### PR TITLE
use is_numeric in findPublishedByIdOrAlias

### DIFF
--- a/src/Model/NewsCategoryModel.php
+++ b/src/Model/NewsCategoryModel.php
@@ -144,7 +144,7 @@ WHERE {$relation['reference_field']} IN (SELECT id FROM tl_news WHERE pid IN (".
         // Determine the alias condition
         if (is_numeric($idOrAlias)) {
             $columns[] = "$t.id=?";
-            $values[] = $idOrAlias;
+            $values[] = (int) $idOrAlias;
         } else {
             if (MultilingualHelper::isActive()) {
                 $columns[] = '(t1.alias=? OR t2.alias=?)';
@@ -152,7 +152,7 @@ WHERE {$relation['reference_field']} IN (SELECT id FROM tl_news WHERE pid IN (".
                 $values[] = $idOrAlias;
             } else {
                 $columns[] = "$t.alias=?";
-                $values[] = (int) $idOrAlias;
+                $values[] = $idOrAlias;
             }
         }
 

--- a/src/Model/NewsCategoryModel.php
+++ b/src/Model/NewsCategoryModel.php
@@ -137,18 +137,24 @@ WHERE {$relation['reference_field']} IN (SELECT id FROM tl_news WHERE pid IN (".
      */
     public static function findPublishedByIdOrAlias($idOrAlias)
     {
-        $values = [$idOrAlias];
+        $values = [];
+        $columns = [];
         $t = static::getTableAlias();
 
         // Determine the alias condition
-        if (MultilingualHelper::isActive()) {
-            $aliasCondition = 't1.alias=? OR t2.alias=?';
+        if (is_numeric($idOrAlias)) {
+            $columns[] = "$t.id=?";
             $values[] = $idOrAlias;
         } else {
-            $aliasCondition = "$t.alias=?";
+            if (MultilingualHelper::isActive()) {
+                $columns[] = 't1.alias=? OR t2.alias=?';
+                $values[] = $idOrAlias;
+                $values[] = $idOrAlias;
+            } else {
+                $columns[] = "$t.alias=?";
+                $values[] = $idOrAlias;
+            }
         }
-
-        $columns = is_numeric($idOrAlias) ? ["$t.id=?"] : [$aliasCondition];
 
         if (!BE_USER_LOGGED_IN) {
             $columns[] = "$t.published=?";

--- a/src/Model/NewsCategoryModel.php
+++ b/src/Model/NewsCategoryModel.php
@@ -144,13 +144,11 @@ WHERE {$relation['reference_field']} IN (SELECT id FROM tl_news WHERE pid IN (".
         if (MultilingualHelper::isActive()) {
             $aliasCondition = 't1.alias=? OR t2.alias=?';
             $values[] = $idOrAlias;
-            $values[] = $idOrAlias;
         } else {
             $aliasCondition = "$t.alias=?";
-            $values[] = $idOrAlias;
         }
 
-        $columns = ["($t.id=? OR $aliasCondition)"];
+        $columns = is_numeric($idOrAlias) ? ["$t.id=?"] : [$aliasCondition];
 
         if (!BE_USER_LOGGED_IN) {
             $columns[] = "$t.published=?";

--- a/src/Model/NewsCategoryModel.php
+++ b/src/Model/NewsCategoryModel.php
@@ -147,12 +147,12 @@ WHERE {$relation['reference_field']} IN (SELECT id FROM tl_news WHERE pid IN (".
             $values[] = $idOrAlias;
         } else {
             if (MultilingualHelper::isActive()) {
-                $columns[] = 't1.alias=? OR t2.alias=?';
+                $columns[] = '(t1.alias=? OR t2.alias=?)';
                 $values[] = $idOrAlias;
                 $values[] = $idOrAlias;
             } else {
                 $columns[] = "$t.alias=?";
-                $values[] = $idOrAlias;
+                $values[] = (int) $idOrAlias;
             }
         }
 


### PR DESCRIPTION
Let's say you have the following categories:

* Lorem
* 1 Ipsum

The _autogenerated_ aliases of these categories would be

* `lorem`
* `1-ipsum`

If you then try to fetch the second category via
```php
NewsCategoryModel::findPublishedByIdOrAlias('1-ipsum')
```
it will instead find the _first_ category, since the MySQL server auto-casts the parameter to an integer for the `id = ?` part of the query, which in this case will be the integer `1` - and that happens to coincide with the ID of the first category.

I noticed this problem with the category menu - since the active category was not marked as active. During debugging I noticed, that the `activeCategory` of `NewsCategoriesModule` was set to a completely different category - due to the aforementioned problem.

Contao had the same problem, it also uses the `is_numeric` check now.