### PR TITLE
add featured sorting options

### DIFF
--- a/src/Criteria/NewsCriteria.php
+++ b/src/Criteria/NewsCriteria.php
@@ -84,6 +84,9 @@ class NewsCriteria
             case 'order_date_asc':
                 $this->options['order'] = "$t.date";
                 break;
+            case 'order_featured_asc':
+                $this->options['order'] = "$t.featured DESC, $t.date";
+				break;
             case 'order_featured_desc':
                 $this->options['order'] = "$t.featured DESC, $t.date DESC";
                 break;

--- a/src/Criteria/NewsCriteria.php
+++ b/src/Criteria/NewsCriteria.php
@@ -84,6 +84,9 @@ class NewsCriteria
             case 'order_date_asc':
                 $this->options['order'] = "$t.date";
                 break;
+            case 'order_featured_desc':
+                $this->options['order'] = "$t.featured DESC, $t.date DESC";
+                break;
             default:
                 $this->options['order'] = "$t.date DESC";
                 break;

--- a/src/Criteria/NewsCriteria.php
+++ b/src/Criteria/NewsCriteria.php
@@ -86,7 +86,7 @@ class NewsCriteria
                 break;
             case 'order_featured_asc':
                 $this->options['order'] = "$t.featured DESC, $t.date";
-				break;
+                break;
             case 'order_featured_desc':
                 $this->options['order'] = "$t.featured DESC, $t.date DESC";
                 break;


### PR DESCRIPTION
This will probably be added in Contao 4.8 (https://github.com/contao/contao/pull/371) and is also available via https://github.com/fritzmg/contao-news-sorting in earlier Contao versions - which I am currently making compatible with the news_categories extension. Thus I think it would make sense to add this sorting option as well.