### PR TITLE
update featured sorting to new implementation

### DIFF
--- a/src/Criteria/NewsCriteria.php
+++ b/src/Criteria/NewsCriteria.php
@@ -58,7 +58,7 @@ class NewsCriteria
      *
      * @throws NoNewsException
      */
-    public function setBasicCriteria(array $archives, $sorting = null)
+    public function setBasicCriteria(array $archives, $sorting = null, $featured = null)
     {
         $archives = $this->parseIds($archives);
 
@@ -70,30 +70,32 @@ class NewsCriteria
 
         $this->columns[] = "$t.pid IN(".\implode(',', \array_map('intval', $archives)).')';
 
+        $order = '';
+
+        if ('featured_first' === $featured) {
+            $order .= "$t.featured DESC, ";
+        }
+
         // Set the sorting
         switch ($sorting) {
             case 'order_headline_asc':
-                $this->options['order'] = "$t.headline";
+                $order .= "$t.headline";
                 break;
             case 'order_headline_desc':
-                $this->options['order'] = "$t.headline DESC";
+                $order .= "$t.headline DESC";
                 break;
             case 'order_random':
-                $this->options['order'] = 'RAND()';
+                $order .= 'RAND()';
                 break;
             case 'order_date_asc':
-                $this->options['order'] = "$t.date";
-                break;
-            case 'order_featured_asc':
-                $this->options['order'] = "$t.featured DESC, $t.date";
-                break;
-            case 'order_featured_desc':
-                $this->options['order'] = "$t.featured DESC, $t.date DESC";
+                $order .= "$t.date";
                 break;
             default:
-                $this->options['order'] = "$t.date DESC";
+                $order .= "$t.date DESC";
                 break;
         }
+
+        $this->options['order'] = $order;
 
         // Never return unpublished elements in the back end, so they don't end up in the RSS feed
         if (!BE_USER_LOGGED_IN || TL_MODE === 'BE') {

--- a/src/Criteria/NewsCriteriaBuilder.php
+++ b/src/Criteria/NewsCriteriaBuilder.php
@@ -93,7 +93,7 @@ class NewsCriteriaBuilder implements FrameworkAwareInterface
         $criteria = new NewsCriteria($this->framework);
 
         try {
-            $criteria->setBasicCriteria($archives, $module->news_order);
+            $criteria->setBasicCriteria($archives, $module->news_order, $module->news_featured);
 
             // Set the featured filter
             if (null !== $featured) {


### PR DESCRIPTION
Follow up PR to #161. The implementation for Contao 4.8 has since changed: https://github.com/contao/contao/commit/f5748dbb0a0a891ee12fc63656c0d7ed6a4dcd8b

The `fritzmg/contao-news-sorting` extension also uses the new implementation now (with version 2.0.0).