### PR TITLE
Replace old news_categories extension

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -29,7 +29,7 @@ class Plugin implements BundlePluginInterface
                 ContaoCoreBundle::class,
                 ContaoNewsBundle::class,
                 'haste',
-            ]),
+            ])->setReplace(['news_categories']),
         ];
     }
 }


### PR DESCRIPTION
Some Contao 3 extensions might have defined

```
requires[] = "news_categories"
```

or

```
requires[] = "*news_categories"
```

in their `autoload.ini`. This will only work for `>=3.0` if you define in the manager plugin, that it replaces the old `news_categories` extension.