### PR TITLE
Use contao.slug if available

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: codefog

--- a/src/EventListener/DataContainer/NewsCategoryListener.php
+++ b/src/EventListener/DataContainer/NewsCategoryListener.php
@@ -57,7 +57,7 @@ class NewsCategoryListener implements FrameworkAwareInterface
      * @param PermissionChecker $permissionChecker
      * @param SessionInterface  $session
      */
-    public function __construct(Connection $db, PermissionChecker $permissionChecker, SessionInterface $session, ?Slug $slug)
+    public function __construct(Connection $db, PermissionChecker $permissionChecker, SessionInterface $session, Slug $slug = null)
     {
         $this->db = $db;
         $this->permissionChecker = $permissionChecker;
@@ -236,12 +236,9 @@ class NewsCategoryListener implements FrameworkAwareInterface
             $title = $dc->activeRecord->frontendTitle ?: $dc->activeRecord->title;
 
             if (null !== $this->slug) {
-                /** @var Config $configAdapter */
-                $configAdapter = $this->framework->getAdapter(Config::class);
-
                 $slugOptions = [];
 
-                if (!empty($validChars = $configAdapter->get('news_categorySlugSetting'))) {
+                if (!empty($validChars = Config::get('news_categorySlugSetting'))) {
                     $slugOptions['validChars'] = $validChars;
                 }
 

--- a/src/EventListener/DataContainer/NewsCategoryListener.php
+++ b/src/EventListener/DataContainer/NewsCategoryListener.php
@@ -13,9 +13,11 @@ namespace Codefog\NewsCategoriesBundle\EventListener\DataContainer;
 use Codefog\NewsCategoriesBundle\MultilingualHelper;
 use Codefog\NewsCategoriesBundle\PermissionChecker;
 use Contao\Backend;
+use Contao\Config;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
+use Contao\CoreBundle\Slug\Slug;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\Input;
@@ -44,17 +46,23 @@ class NewsCategoryListener implements FrameworkAwareInterface
     private $session;
 
     /**
+     * @var Slug
+     */
+    private $slug;
+
+    /**
      * NewsCategoryListener constructor.
      *
      * @param Connection        $db
      * @param PermissionChecker $permissionChecker
      * @param SessionInterface  $session
      */
-    public function __construct(Connection $db, PermissionChecker $permissionChecker, SessionInterface $session)
+    public function __construct(Connection $db, PermissionChecker $permissionChecker, SessionInterface $session, ?Slug $slug)
     {
         $this->db = $db;
         $this->permissionChecker = $permissionChecker;
         $this->session = $session;
+        $this->slug = $slug;
     }
 
     /**
@@ -225,7 +233,26 @@ class NewsCategoryListener implements FrameworkAwareInterface
         // Generate alias if there is none
         if (!$value) {
             $autoAlias = true;
-            $value = StringUtil::generateAlias($dc->activeRecord->frontendTitle ?: $dc->activeRecord->title);
+            $title = $dc->activeRecord->frontendTitle ?: $dc->activeRecord->title;
+
+            if (null !== $this->slug) {
+                /** @var Config $configAdapter */
+                $configAdapter = $this->framework->getAdapter(Config::class);
+
+                $slugOptions = [];
+
+                if (!empty($validChars = $configAdapter->get('news_categorySlugSetting'))) {
+                    $slugOptions['validChars'] = $validChars;
+                }
+
+                if (MultilingualHelper::isActive() && $dc instanceof Driver) {
+                    $slugOptions['locale'] = $dc->getCurrentLanguage();
+                }
+
+                $value = $this->slug->generate($title, $slugOptions);
+            } else {
+                $value = StringUtil::generateAlias($title);
+            }
         }
 
         if (MultilingualHelper::isActive() && $dc instanceof Driver) {

--- a/src/EventListener/DataContainer/SettingsListener.php
+++ b/src/EventListener/DataContainer/SettingsListener.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * News Categories bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2020, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+namespace Codefog\NewsCategoriesBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\Slug\ValidCharacters;
+
+class SettingsListener
+{
+    private $validCharacters;
+
+    public function __construct(ValidCharacters $validCharacters = null)
+    {
+        $this->validCharacters = $validCharacters;
+    }
+
+    /**
+     * On slug setting options callback
+     *
+     * @return array
+     */
+    public function onSlugSettingOptionsCallback()
+    {
+        return $this->validCharacters->getOptions();
+    }
+}

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -55,6 +55,7 @@ services:
             - "@database_connection"
             - "@codefog_news_categories.permission_checker"
             - "@session"
+            - "@?contao.slug"
 
     codefog_news_categories.listener.data_container.news:
         class: Codefog\NewsCategoriesBundle\EventListener\DataContainer\NewsListener

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -62,3 +62,8 @@ services:
         arguments:
             - "@database_connection"
             - "@codefog_news_categories.permission_checker"
+
+    codefog_news_categories.listener.data_container.settings:
+        class: Codefog\NewsCategoriesBundle\EventListener\DataContainer\SettingsListener
+        arguments:
+            - "@?contao.slug.valid_characters"

--- a/src/Resources/contao/dca/tl_settings.php
+++ b/src/Resources/contao/dca/tl_settings.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * News Categories bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2020, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+$GLOBALS['TL_DCA']['tl_settings']['fields']['news_categorySlugSetting'] = [
+    'inputType' => 'select',
+    'options_callback' => static function () {
+        return Contao\System::getContainer()->get('contao.slug.valid_characters')->getOptions();
+    },
+    'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true,  'decodeEntities' => true],
+];
+
+PaletteManipulator::create()
+    ->addLegend('news_categories_legend', null, PaletteManipulator::POSITION_AFTER, true)
+    ->addField('news_categorySlugSetting', 'news_categories_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('default', 'tl_settings')
+;

--- a/src/Resources/contao/dca/tl_settings.php
+++ b/src/Resources/contao/dca/tl_settings.php
@@ -9,17 +9,18 @@
  */
 
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\CoreBundle\Slug\Slug;
 
-$GLOBALS['TL_DCA']['tl_settings']['fields']['news_categorySlugSetting'] = [
-    'inputType' => 'select',
-    'options_callback' => static function () {
-        return Contao\System::getContainer()->get('contao.slug.valid_characters')->getOptions();
-    },
-    'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true,  'decodeEntities' => true],
-];
+if (\class_exists(Slug::class)) {
+    $GLOBALS['TL_DCA']['tl_settings']['fields']['news_categorySlugSetting'] = [
+        'inputType' => 'select',
+        'options_callback' => ['codefog_news_categories.listener.data_container.settings', 'onSlugSettingOptionsCallback'],
+        'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true,  'decodeEntities' => true],
+    ];
 
-PaletteManipulator::create()
-    ->addLegend('news_categories_legend', null, PaletteManipulator::POSITION_AFTER, true)
-    ->addField('news_categorySlugSetting', 'news_categories_legend', PaletteManipulator::POSITION_APPEND)
-    ->applyToPalette('default', 'tl_settings')
-;
+    PaletteManipulator::create()
+        ->addLegend('news_categories_legend', null, PaletteManipulator::POSITION_AFTER, true)
+        ->addField('news_categorySlugSetting', 'news_categories_legend', PaletteManipulator::POSITION_APPEND)
+        ->applyToPalette('default', 'tl_settings')
+    ;
+}

--- a/src/Resources/contao/languages/de/tl_settings.php
+++ b/src/Resources/contao/languages/de/tl_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+/*
+ * News Categories bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2020, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+$GLOBALS['TL_LANG']['tl_settings']['news_categories_legend'] = 'Nachrichten-Kategorien';

--- a/src/Resources/contao/languages/en/tl_settings.php
+++ b/src/Resources/contao/languages/en/tl_settings.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * News Categories bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2020, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+use Contao\System;
+
+System::loadLanguageFile('tl_page');
+
+$GLOBALS['TL_LANG']['tl_settings']['news_categories_legend'] = 'News categories';
+$GLOBALS['TL_LANG']['tl_settings']['news_categorySlugSetting'] = &$GLOBALS['TL_LANG']['tl_page']['validAliasCharacters'];


### PR DESCRIPTION
This PR implements the usage of the `contao.slug` service, if available. It adds a system setting, where you can configure the valid characters for the alias generation, just as you would be able to in the settings of a website root. It also considers the configured locale, when using `terminal42/dc_multilingual`.