### PR TITLE
Add FQCN alias for categories manager

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,6 +7,8 @@ services:
             calls:
                 - ["setFramework", ["@contao.framework"]]
 
+    Codefog\NewsCategoriesBundle\NewsCategoriesManager: '@codefog_news_categories.manager'
+
     codefog_news_categories.manager:
         class: Codefog\NewsCategoriesBundle\NewsCategoriesManager
 


### PR DESCRIPTION
When using auto-wiring in your `App\` it would be helpful to have this alias, so that you can omit putting

```yml
services:
    _defaults:
        bind:
            $newsCategoriesManager: '@codefog_news_categories.manager'
```

into your `config/services.yml`. Thus all you need will be

```yml
services:
    _defaults:
        autowire: true
        autoconfigure: true

    App\:
        resource: ../src
```

(or actually nothing at all since Contao 4.9) in order to get the news categories manager service automatically injected into your service when requested in its constructor.