### PR TITLE
Fixed Problem with category parameters in changelanguage modules

### DIFF
--- a/src/EventListener/ChangeLanguageListener.php
+++ b/src/EventListener/ChangeLanguageListener.php
@@ -91,8 +91,16 @@ class ChangeLanguageListener implements FrameworkAwareInterface
             return;
         }
 
-        $attributes[$newParam] = $attributes[$currentParam];
-        unset($attributes[$currentParam]);
+        if ($event->getNavigationItem()->isDirectFallback()) {
+            // only add or change category param if the fallback page is a direct fallback
+            $attributes[$newParam] = $attributes[$currentParam];
+            if ($newParam !== $currentParam) {
+                unset($attributes[$currentParam]);
+            }
+        } else {
+            // remove category param completely
+            unset($attributes[$currentParam]);
+        }
 
         $parameters->setUrlAttributes($attributes);
     }


### PR DESCRIPTION
Hi there,
I had a little problem with the extension in interaction with the contao-changelanguage module. Specifically, the category parameter was added in the language navigation even for pages that are not "direct" language fallbacks.
This then led to the root pages of the respective languages being linked and the category parameters being appended here.
Enclosed is my suggestion for the bugfix.