### PR TITLE
Avoid array offset warning under PHP 8

### DIFF
--- a/src/Resources/contao/dca/tl_news_feed.php
+++ b/src/Resources/contao/dca/tl_news_feed.php
@@ -43,7 +43,7 @@ $GLOBALS['TL_DCA']['tl_news_feed']['fields']['categories_show'] = [
     'reference' => &$GLOBALS['TL_LANG']['tl_news_feed']['categories_show'],
     'eval' => [
         'includeBlankOption' => true,
-        'blankOptionLabel' => $GLOBALS['TL_LANG']['tl_news_feed']['categories_show']['empty'],
+        'blankOptionLabel' => isset($GLOBALS['TL_LANG']['tl_news_feed']['categories_show']['empty']) ? $GLOBALS['TL_LANG']['tl_news_feed']['categories_show']['empty'] : null,
         'tl_class' => 'w50',
     ],
     'sql' => ['type' => 'string', 'length' => 16, 'default' => ''],


### PR DESCRIPTION
When running `php bin/console contao:migrate` after the installtion of the bundle under PHP8 following error occures:

```
$ php bin/console contao:migrate -vvv

In tl_news_feed.php line 46:
                                                                
  [ErrorException]                                              
  Warning: Trying to access array offset on value of type null  
                                                                

Exception trace:
  at /vendor/codefog/contao-news_categories/src/Resources/contao/dca/tl_news_feed.php:46
 include() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php:108
 Contao\DcaLoader->loadDcaFiles() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php:70
 Contao\DcaLoader->load() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:1361
 Contao\Controller::loadDataContainer() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php:380
 Contao\DcaExtractor->createExtract() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php:128
 Contao\DcaExtractor->__construct() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php:150
 Contao\DcaExtractor::getInstance() at /vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database/Installer.php:285
 Contao\Database\Installer->getFromDca() at /vendor/contao/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php:303
 Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider->getSqlDefinitions() at /vendor/contao/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php:66
 Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider->appendToSchema() at /vendor/contao/core-bundle/src/EventListener/DoctrineSchemaListener.php:38
 Contao\CoreBundle\EventListener\DoctrineSchemaListener->postGenerateSchema() at /vendor/symfony/doctrine-bridge/ContainerAwareEventManager.php:64
 Symfony\Bridge\Doctrine\ContainerAwareEventManager->dispatchEvent() at /vendor/doctrine/orm/lib/Doctrine/ORM/Tools/SchemaTool.php:415
 Doctrine\ORM\Tools\SchemaTool->getSchemaFromMetadata() at /vendor/contao/core-bundle/src/Doctrine/Schema/SchemaProvider.php:43
 Contao\CoreBundle\Doctrine\Schema\SchemaProvider->createSchema() at /vendor/contao/installation-bundle/src/Database/Installer.php:126
 Contao\InstallationBundle\Database\Installer->compileCommands() at /vendor/contao/core-bundle/src/Command/MigrateCommand.php:228
 Contao\CoreBundle\Command\MigrateCommand->executeSchemaDiff() at /vendor/contao/core-bundle/src/Command/MigrateCommand.php:109
 Contao\CoreBundle\Command\MigrateCommand->execute() at /vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /vendor/symfony/console/Application.php:1027
 Symfony\Component\Console\Application->doRunCommand() at /vendor/symfony/framework-bundle/Console/Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /vendor/symfony/console/Application.php:273
 Symfony\Component\Console\Application->doRun() at /vendor/symfony/framework-bundle/Console/Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /vendor/symfony/console/Application.php:149
 Symfony\Component\Console\Application->run() at /bin/console:46
```