### PR TITLE
Always create empty template variables

### DIFF
--- a/src/EventListener/TemplateListener.php
+++ b/src/EventListener/TemplateListener.php
@@ -58,6 +58,8 @@ class TemplateListener implements FrameworkAwareInterface
         $newsCategoryModelAdapter = $this->framework->getAdapter(NewsCategoryModel::class);
 
         if (null === ($models = $newsCategoryModelAdapter->findPublishedByNews($data['id']))) {
+            $template->categories = [];
+            $template->categoriesList = [];
             return;
         }
 


### PR DESCRIPTION
If all categories of a news record get unpublished for example, then the `$this->categories` template variable will still contain the serialized string from the database (from the categories selection widget). If your template only contains

```php
<?php if ($this->categories): ?>
  <ul class="categories">
    <?php foreach ($this->categories as $category): ?>
```

for example this will then fail with "invalid argument supplied for foreach", since `$this->categories` will be a string in this case.

So if no (published) categories are available, these template variables should be an empty array (or at least `null`).