### PR TITLE
Update DBAL statements to support Contao 4.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,14 @@
         "php": "^5.6|^7.0|^8.0",
         "contao/core-bundle": "^4.4",
         "codefog/contao-haste": "^4.17",
-        "contao/news-bundle": "^4.4"
+        "contao/news-bundle": "^4.4",
+        "doctrine/dbal": "^2.11 || ^3"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.2",
         "terminal42/contao-changelanguage": "^3.1",
-        "terminal42/dc_multilingual": "^3.0"
+        "terminal42/dc_multilingual": "^4.0"
     },
     "suggest": {
         "terminal42/contao-changelanguage": "^3.1",

--- a/src/Criteria/NewsCriteriaBuilder.php
+++ b/src/Criteria/NewsCriteriaBuilder.php
@@ -239,11 +239,11 @@ class NewsCriteriaBuilder implements FrameworkAwareInterface
         }
 
         $categories = \array_map('intval', $categories);
-        $excluded = $this->db->fetchAll('SELECT id FROM tl_news_category WHERE excludeInRelated=1');
+        $excluded = $this->db->fetchFirstColumn('SELECT id FROM tl_news_category WHERE excludeInRelated=1');
 
         // Exclude the categories
         foreach ($excluded as $category) {
-            if (false !== ($index = \array_search((int) $category['id'], $categories, true))) {
+            if (false !== ($index = \array_search((int) $category, $categories, true))) {
                 unset($categories[$index]);
             }
         }

--- a/src/EventListener/DataContainer/ContentListener.php
+++ b/src/EventListener/DataContainer/ContentListener.php
@@ -37,7 +37,7 @@ class ContentListener
     public function onGetNewsModules()
     {
         $modules = [];
-        $records = $this->db->fetchAll("SELECT m.id, m.name, t.name AS theme FROM tl_module m LEFT JOIN tl_theme t ON m.pid=t.id WHERE m.type IN ('newslist', 'newsarchive') ORDER BY t.name, m.name");
+        $records = $this->db->fetchAllAssociative("SELECT m.id, m.name, t.name AS theme FROM tl_module m LEFT JOIN tl_theme t ON m.pid=t.id WHERE m.type IN ('newslist', 'newsarchive') ORDER BY t.name, m.name");
 
         foreach ($records as $record) {
             $modules[$record['theme']][$record['id']] = \sprintf('%s (ID %s)', $record['name'], $record['id']);

--- a/src/EventListener/DataContainer/FeedListener.php
+++ b/src/EventListener/DataContainer/FeedListener.php
@@ -81,9 +81,7 @@ class FeedListener implements FrameworkAwareInterface
             $newsIds = \array_map('intval', \array_unique($newsIds));
 
             if (\count($newsIds) > 0) {
-                $archiveIds = $this->db
-                    ->executeQuery('SELECT DISTINCT(pid) FROM tl_news WHERE id IN ('.\implode(',', $newsIds).')')
-                    ->fetchAll(\PDO::FETCH_COLUMN, 0);
+                $archiveIds = $this->db->fetchFirstColumn('SELECT DISTINCT(pid) FROM tl_news WHERE id IN ('.\implode(',', $newsIds).')');
 
                 $session = $this->session->get('news_feed_updater');
                 $session = \array_merge((array) $session, $archiveIds);

--- a/src/EventListener/DataContainer/NewsCategoryListener.php
+++ b/src/EventListener/DataContainer/NewsCategoryListener.php
@@ -253,12 +253,12 @@ class NewsCategoryListener implements FrameworkAwareInterface
         }
 
         if (MultilingualHelper::isActive() && $dc instanceof Driver) {
-            $exists = $this->db->fetchColumn(
+            $exists = $this->db->fetchOne(
                 "SELECT id FROM {$dc->table} WHERE alias=? AND id!=? AND {$dc->getLanguageColumn()}=?",
                 [$value, $dc->activeRecord->id, $dc->getCurrentLanguage()]
             );
         } else {
-            $exists = $this->db->fetchColumn(
+            $exists = $this->db->fetchOne(
                 "SELECT id FROM {$dc->table} WHERE alias=? AND id!=?",
                 [$value, $dc->activeRecord->id]
             );

--- a/src/EventListener/DataContainer/NewsListener.php
+++ b/src/EventListener/DataContainer/NewsListener.php
@@ -61,9 +61,9 @@ class NewsListener implements FrameworkAwareInterface
 
         // Handle the edit all modes differently
         if ($input->get('act') === 'editAll' || $input->get('act') === 'overrideAll') {
-            $categories = $this->db->fetchColumn('SELECT categories FROM tl_news_archive WHERE limitCategories=1 AND id=?', [$dc->id]);
+            $categories = $this->db->fetchFirstColumn('SELECT categories FROM tl_news_archive WHERE limitCategories=1 AND id=?', [$dc->id]);
         } else {
-            $categories = $this->db->fetchColumn('SELECT categories FROM tl_news_archive WHERE limitCategories=1 AND id=(SELECT pid FROM tl_news WHERE id=?)', [$dc->id]);
+            $categories = $this->db->fetchFirstColumn('SELECT categories FROM tl_news_archive WHERE limitCategories=1 AND id=(SELECT pid FROM tl_news WHERE id=?)', [$dc->id]);
         }
 
         if (!$categories || 0 === \count($categories = StringUtil::deserialize($categories, true))) {
@@ -123,7 +123,7 @@ class NewsListener implements FrameworkAwareInterface
     private function generateOptionsRecursively($pid = 0, $prefix = '')
     {
         $options = [];
-        $records = $this->db->fetchAll('SELECT * FROM tl_news_category WHERE pid=? ORDER BY sorting', [$pid]);
+        $records = $this->db->fetchAllAssociative('SELECT * FROM tl_news_category WHERE pid=? ORDER BY sorting', [$pid]);
 
         foreach ($records as $record) {
             $options[$record['id']] = $prefix . $record['title'];

--- a/src/PermissionChecker.php
+++ b/src/PermissionChecker.php
@@ -135,7 +135,7 @@ class PermissionChecker implements FrameworkAwareInterface
 
         // Add the permissions on group level
         if ('custom' !== $user->inherit) {
-            $groups = $this->db->fetchAll('SELECT id, newscategories, newscategories_roots FROM tl_user_group WHERE id IN('.\implode(',', \array_map('intval', $user->groups)).')');
+            $groups = $this->db->fetchAllAssociative('SELECT id, newscategories, newscategories_roots FROM tl_user_group WHERE id IN('.\implode(',', \array_map('intval', $user->groups)).')');
 
             foreach ($groups as $group) {
                 $permissions = $stringUtil->deserialize($group['newscategories'], true);
@@ -151,7 +151,7 @@ class PermissionChecker implements FrameworkAwareInterface
 
         // Add the permissions on user level
         if ('group' !== $user->inherit) {
-            $userData = $this->db->fetchAssoc('SELECT newscategories, newscategories_roots FROM tl_user WHERE id=?', [$user->id]);
+            $userData = $this->db->fetchAssociative('SELECT newscategories, newscategories_roots FROM tl_user WHERE id=?', [$user->id]);
             $permissions = $stringUtil->deserialize($userData['newscategories'], true);
 
             if (\in_array('manage', $permissions, true)) {


### PR DESCRIPTION
Contao 4.13 requires doctrine/dbal 3, which has some incompatibilities. Fortunately, Doctrine 2.11+ already has the new methods, so we can be BC with both versions. I hope I catched all deprecated method calls.

PS: also fixed invalid `require-dev` 😉 