### PR TITLE
Fix image options in Contao 4.13

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -190,3 +190,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['news_categoryFilterPage'] = [
 $GLOBALS['TL_DCA']['tl_module']['fields']['news_categoryImgSize'] = $GLOBALS['TL_DCA']['tl_module']['fields']['imgSize'];
 unset($GLOBALS['TL_DCA']['tl_module']['fields']['news_categoryImgSize']['label']);
 $GLOBALS['TL_DCA']['tl_module']['fields']['news_categoryImgSize']['label'] = &$GLOBALS['TL_LANG']['tl_module']['news_categoryImgSize'];
+
+if (class_exists(\Contao\CoreBundle\EventListener\ImageSizeOptionsListener::class)) {
+    $GLOBALS['TL_DCA']['tl_module']['fields']['news_categoryImgSize']['options_callback'] = ['contao.listener.image_size_options', '__invoke'];
+}


### PR DESCRIPTION
Contao removed the `options_callback` in https://github.com/contao/contao/pull/3630 and the listener obviously does not add it to our cloned field.