### PR TITLE
Fix PHP 8 warning in AjaxListener

### DIFF
--- a/src/EventListener/AjaxListener.php
+++ b/src/EventListener/AjaxListener.php
@@ -116,7 +116,7 @@ class AjaxListener implements FrameworkAwareInterface
         }
 
         // Call the load_callback
-        if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['load_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$field]['load_callback'] ?? null)) {
             /** @var System $systemAdapter */
             $systemAdapter = $this->framework->getAdapter(System::class);
 


### PR DESCRIPTION
Fixes the following warning:

```
ErrorException:
Warning: Undefined array key "load_callback"

  at vendor\codefog\contao-news_categories\src\EventListener\AjaxListener.php:119
  at Codefog\NewsCategoriesBundle\EventListener\AjaxListener->reloadNewsCategoriesWidget(object(DC_Table))
     (vendor\codefog\contao-news_categories\src\EventListener\AjaxListener.php:56)
  at Codefog\NewsCategoriesBundle\EventListener\AjaxListener->onExecutePostActions('reloadNewsCategoriesWidget', object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Ajax.php:527)
  at Contao\Ajax->executePostActionsHook(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Ajax.php:509)
  at Contao\Ajax->executePostActions(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:430)
  at Contao\Backend->getBackendModule('themes', null)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:44)      
```

Otherwise you won't be able to select a reference category in the _News categories list_ module for example (in the debug mode).