### PR TITLE
Fix error from missing toggle icon

### DIFF
--- a/src/Resources/contao/dca/tl_news_category.php
+++ b/src/Resources/contao/dca/tl_news_category.php
@@ -103,6 +103,7 @@ $GLOBALS['TL_DCA']['tl_news_category'] = [
             'toggle' => [
                 'label' => &$GLOBALS['TL_LANG']['tl_news_category']['toggle'],
                 'href' => 'act=toggle&amp;field=published',
+                'icon' => 'visible.svg',
                 'attributes' => 'onclick="Backend.getScrollOffset();"',
             ],
         ],


### PR DESCRIPTION
Hi @qzminski, 

missing icon definition from the toggle in last Haste v5 update causes an error.