### PR TITLE
Implement canonical tag for `3.5.x`

### DIFF
--- a/src/FrontendModule/CumulativeFilterModule.php
+++ b/src/FrontendModule/CumulativeFilterModule.php
@@ -56,10 +56,14 @@ class CumulativeFilterModule extends NewsModule
         if (null !== $this->activeCategories) {
             $this->Template->activeCategories = $this->renderNewsCategories($rootCategoryId, $this->activeCategories->fetchEach('id'), true);
 
-            // Add the canonical URL tag
-            // TODO: to be dropped when deps require Contao 4.13+
-            if ($this->news_enableCanonicalUrls && !System::getContainer()->has('contao.routing.response_context_accessor')) {
-                $GLOBALS['TL_HEAD'][] = \sprintf('<link rel="canonical" href="%s">', $GLOBALS['objPage']->getAbsoluteUrl());
+            // Set the canonical URL
+            if ($this->news_enableCanonicalUrls && ($responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext())) {
+                /** @var ResponseContext $responseContext */
+                if ($responseContext->has(HtmlHeadBag::class)) {
+                    /** @var HtmlHeadBag $htmlHeadBag */
+                    $htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+                    $htmlHeadBag->setCanonicalUri($GLOBALS['objPage']->getAbsoluteUrl());
+                }
             }
 
             // Add the "reset categories" link

--- a/src/FrontendModule/CumulativeFilterModule.php
+++ b/src/FrontendModule/CumulativeFilterModule.php
@@ -56,6 +56,12 @@ class CumulativeFilterModule extends NewsModule
         if (null !== $this->activeCategories) {
             $this->Template->activeCategories = $this->renderNewsCategories($rootCategoryId, $this->activeCategories->fetchEach('id'), true);
 
+            // Add the canonical URL tag
+            // TODO: to be dropped when deps require Contao 4.13+
+            if ($this->news_enableCanonicalUrls && !System::getContainer()->has('contao.routing.response_context_accessor')) {
+                $GLOBALS['TL_HEAD'][] = \sprintf('<link rel="canonical" href="%s">', $GLOBALS['objPage']->getAbsoluteUrl());
+            }
+
             // Add the "reset categories" link
             if ($this->news_resetCategories) {
                 $this->Template->resetUrl = $this->getTargetPage()->getFrontendUrl();

--- a/src/FrontendModule/CumulativeHierarchicalFilterModule.php
+++ b/src/FrontendModule/CumulativeHierarchicalFilterModule.php
@@ -33,16 +33,21 @@ class CumulativeHierarchicalFilterModule extends NewsModule
             return;
         }
 
-        $param = System::getContainer()->get('codefog_news_categories.manager')->getParameterName();
+        $container = System::getContainer();
+        $param = $container->get('codefog_news_categories.manager')->getParameterName();
 
         // Get the active category
         if (null !== ($activeCategory = NewsCategoryModel::findPublishedByIdOrAlias(Input::get($param)))) {
             $this->activeCategory = $activeCategory;
 
-            // Add the canonical URL tag
-            // TODO: to be dropped when deps require Contao 4.13+
-            if ($this->news_enableCanonicalUrls && !System::getContainer()->has('contao.routing.response_context_accessor')) {
-                $GLOBALS['TL_HEAD'][] = sprintf('<link rel="canonical" href="%s">', $GLOBALS['objPage']->getAbsoluteUrl());
+            // Set the canonical URL
+            if ($this->news_enableCanonicalUrls && ($responseContext = $container->get('contao.routing.response_context_accessor')->getResponseContext())) {
+                /** @var ResponseContext $responseContext */
+                if ($responseContext->has(HtmlHeadBag::class)) {
+                    /** @var HtmlHeadBag $htmlHeadBag */
+                    $htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+                    $htmlHeadBag->setCanonicalUri($GLOBALS['objPage']->getAbsoluteUrl());
+                }
             }
         }
 

--- a/src/FrontendModule/CumulativeHierarchicalFilterModule.php
+++ b/src/FrontendModule/CumulativeHierarchicalFilterModule.php
@@ -38,6 +38,12 @@ class CumulativeHierarchicalFilterModule extends NewsModule
         // Get the active category
         if (null !== ($activeCategory = NewsCategoryModel::findPublishedByIdOrAlias(Input::get($param)))) {
             $this->activeCategory = $activeCategory;
+
+            // Add the canonical URL tag
+            // TODO: to be dropped when deps require Contao 4.13+
+            if ($this->news_enableCanonicalUrls && !System::getContainer()->has('contao.routing.response_context_accessor')) {
+                $GLOBALS['TL_HEAD'][] = sprintf('<link rel="canonical" href="%s">', $GLOBALS['objPage']->getAbsoluteUrl());
+            }
         }
 
         $ids = [];

--- a/src/FrontendModule/NewsCategoriesModule.php
+++ b/src/FrontendModule/NewsCategoriesModule.php
@@ -48,17 +48,13 @@ class NewsCategoriesModule extends NewsModule
         if (null !== ($activeCategory = NewsCategoryModel::findPublishedByIdOrAlias(Input::get($param)))) {
             $this->activeCategory = $activeCategory;
 
-            // Add the canonical URL tag
-            if ($this->news_enableCanonicalUrls) {
-                if (!$container->has('contao.routing.response_context_accessor')) {
-                    $GLOBALS['TL_HEAD'][] = \sprintf('<link rel="canonical" href="%s">', $GLOBALS['objPage']->getAbsoluteUrl());
-                } elseif ($responseContext = $container->get('contao.routing.response_context_accessor')->getResponseContext()) {
-                    /** @var ResponseContext $responseContext */
-                    if ($responseContext->has(HtmlHeadBag::class)) {
-                        /** @var HtmlHeadBag $htmlHeadBag */
-                        $htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
-                        $htmlHeadBag->setCanonicalUri($GLOBALS['objPage']->getAbsoluteUrl());
-                    }
+            // Set the canonical URL
+            if ($this->news_enableCanonicalUrls && ($responseContext = $container->get('contao.routing.response_context_accessor')->getResponseContext())) {
+                /** @var ResponseContext $responseContext */
+                if ($responseContext->has(HtmlHeadBag::class)) {
+                    /** @var HtmlHeadBag $htmlHeadBag */
+                    $htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+                    $htmlHeadBag->setCanonicalUri($GLOBALS['objPage']->getAbsoluteUrl());
                 }
             }
         }

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -10,9 +10,9 @@
 
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'news_customCategories';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'news_relatedCategories';
-$GLOBALS['TL_DCA']['tl_module']['palettes']['newscategories'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_resetCategories,news_showEmptyCategories,news_includeSubcategories,showLevel;{reference_legend:hide},news_categoriesRoot,news_customCategories;{redirect_legend:hide},news_forceCategoryUrl,jumpTo;{template_legend:hide},navigationTpl,customTpl;{image_legend:hide},news_categoryImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
-$GLOBALS['TL_DCA']['tl_module']['palettes']['newscategories_cumulative'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_resetCategories,news_includeSubcategories,news_filterCategoriesUnion;{reference_legend:hide},news_categoriesRoot,news_customCategories;{redirect_legend:hide},jumpTo;{template_legend:hide},navigationTpl,customTpl;{image_legend:hide},news_categoryImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
-$GLOBALS['TL_DCA']['tl_module']['palettes']['newscategories_cumulativehierarchical'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_resetCategories,news_showEmptyCategories,news_filterCategoriesUnion,news_includeSubcategories,showLevel;{reference_legend:hide},news_categoriesRoot,news_customCategories;{redirect_legend:hide},news_forceCategoryUrl,jumpTo;{template_legend:hide},navigationTpl,customTpl;{image_legend:hide},news_categoryImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['newscategories'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_resetCategories,news_showEmptyCategories,news_enableCanonicalUrls,news_includeSubcategories,showLevel;{reference_legend:hide},news_categoriesRoot,news_customCategories;{redirect_legend:hide},news_forceCategoryUrl,jumpTo;{template_legend:hide},navigationTpl,customTpl;{image_legend:hide},news_categoryImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['newscategories_cumulative'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_resetCategories,news_enableCanonicalUrls,news_includeSubcategories,news_filterCategoriesUnion;{reference_legend:hide},news_categoriesRoot,news_customCategories;{redirect_legend:hide},jumpTo;{template_legend:hide},navigationTpl,customTpl;{image_legend:hide},news_categoryImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['newscategories_cumulativehierarchical'] = '{title_legend},name,headline,type;{config_legend},news_archives,news_showQuantity,news_resetCategories,news_showEmptyCategories,news_enableCanonicalUrls,news_filterCategoriesUnion,news_includeSubcategories,showLevel;{reference_legend:hide},news_categoriesRoot,news_customCategories;{redirect_legend:hide},news_forceCategoryUrl,jumpTo;{template_legend:hide},navigationTpl,customTpl;{image_legend:hide},news_categoryImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['news_customCategories'] = 'news_categories';
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['news_relatedCategories'] = 'news_relatedCategoriesOrder,news_categoriesRoot';
 
@@ -118,6 +118,14 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['news_filterCategoriesUnion'] = [
     'exclude' => true,
     'inputType' => 'checkbox',
     'eval' => ['tl_class' => 'clr'],
+    'sql' => ['type' => 'boolean', 'default' => 0],
+];
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['news_enableCanonicalUrls'] = [
+    'label' => &$GLOBALS['TL_LANG']['tl_module']['news_enableCanonicalUrls'],
+    'exclude' => true,
+    'inputType' => 'checkbox',
+    'eval' => ['tl_class' => 'w50'],
     'sql' => ['type' => 'boolean', 'default' => 0],
 ];
 

--- a/src/Resources/contao/languages/de/tl_module.php
+++ b/src/Resources/contao/languages/de/tl_module.php
@@ -19,6 +19,7 @@ $GLOBALS['TL_LANG']['tl_module']['news_relatedCategories'] = ['Nach verwandten K
 $GLOBALS['TL_LANG']['tl_module']['news_relatedCategoriesOrder'] = ['Sortierung der Beiträge verwandter Kategorien', 'Hier kann die Sortierung der verwandten Nachrichtenbeiträge ausgewählt werden.'];
 $GLOBALS['TL_LANG']['tl_module']['news_includeSubcategories'] = ['Unterkategorien miteinbeziehen', 'Berücksichtigt Unterkategorien bei der Filterung wenn eine übergeordnete Kategorie aktiv ist.'];
 $GLOBALS['TL_LANG']['tl_module']['news_filterCategoriesUnion'] = ['Kategorie Filterung über Vereinigung (nur kumulativ)', 'Filtert Nachrichtenbeiträge und Kategorien vereinigt (x OR y) statt der Schnittmenge (x AND y).'];
+$GLOBALS['TL_LANG']['tl_module']['news_enableCanonicalUrls'] = ['Canonical URL einfügen', 'Fügt bei aktiver Kategorieauswahl einen Canonical-Tag im Head der Webseite ein.'];
 $GLOBALS['TL_LANG']['tl_module']['news_filterDefault'] = ['Standard-Filter', 'Hier kann der Standard-Filter für die Nachrichtenliste gewählt werden.'];
 $GLOBALS['TL_LANG']['tl_module']['news_filterPreserve'] = ['Standard-Filter aktivieren', 'Die Standard-Filtereinstellungen gelten auch dann, wenn eine aktive Kategorie ausgewählt wurde.'];
 $GLOBALS['TL_LANG']['tl_module']['news_resetCategories'] = ['Kategorie-Filter zurücksetzen', 'Fügt einen Link hinzu, um die Filter zurückzusetzen.'];

--- a/src/Resources/contao/languages/en/tl_module.php
+++ b/src/Resources/contao/languages/en/tl_module.php
@@ -19,6 +19,7 @@ $GLOBALS['TL_LANG']['tl_module']['news_relatedCategories'] = ['Related categorie
 $GLOBALS['TL_LANG']['tl_module']['news_relatedCategoriesOrder'] = ['Related categories order', 'Here you can choose the related categories order.'];
 $GLOBALS['TL_LANG']['tl_module']['news_includeSubcategories'] = ['Include the subcategories', 'Include the subcategories in the filtering if the parent category is active.'];
 $GLOBALS['TL_LANG']['tl_module']['news_filterCategoriesUnion'] = ['Filter by categories using union (cumulative only)', 'Filter news and categories using union (x OR y) instead of intersection (x AND y).'];
+$GLOBALS['TL_LANG']['tl_module']['news_enableCanonicalUrls'] = ['Enable canonical URLs', 'Adds the canonical URL tag when active category is present.'];
 $GLOBALS['TL_LANG']['tl_module']['news_filterDefault'] = ['Default filter', 'Here you can choose the default filter that will be applied to the newslist.'];
 $GLOBALS['TL_LANG']['tl_module']['news_filterPreserve'] = ['Preserve the default filter', 'Preserve the default filter settings even if there is an active category selected.'];
 $GLOBALS['TL_LANG']['tl_module']['news_resetCategories'] = ['Reset categories link', 'Add a link to reset categories filter.'];


### PR DESCRIPTION
This reverts c2aa43aba6dc7b45124a979e7fc34d087036ec3b and instead implements setting the canonical URL in the `HtmlHeadBag`.

_Note:_ #248 should be merged before this.