### PR TITLE
check for insert tag parser

### DIFF
--- a/src/FeedGenerator.php
+++ b/src/FeedGenerator.php
@@ -14,6 +14,7 @@ use Codefog\NewsCategoriesBundle\Criteria\NewsCriteria;
 use Codefog\NewsCategoriesBundle\Exception\NoNewsException;
 use Codefog\NewsCategoriesBundle\Model\NewsCategoryModel;
 use Contao\Config;
+use Contao\Controller;
 use Contao\News;
 use Contao\PageModel;
 use Contao\System;
@@ -192,7 +193,12 @@ class FeedGenerator extends News
                     }
                 }
 
-                $strDescription = $container->get('contao.insert_tag.parser')->replaceInline($strDescription);
+                if ($container->has('contao.insert_tag.parser')) {
+                    $strDescription = $container->get('contao.insert_tag.parser')->replaceInline($strDescription);
+                } else {
+                    $strDescription = Controller::replaceInsertTags($strDescription);
+                }
+
                 $objItem->description = $this->convertRelativeUrls($strDescription, $strLink);
 
                 // Add the article image as enclosure


### PR DESCRIPTION
In 8a54d8143ff703417cec5560179d081469eeb1eb usage of the new insert tag parser was introduced. However that service does not exist in Contao 4.4 or 4.9 yet - but the dependencies for `3.4.x` still require only Contao 4.4 and up.

This PR fixes that.

_Note:_ this does not need to be merged upstream.