### PR TITLE
Fix compatibility with Doctrine `2.x`

### DIFF
--- a/src/PermissionChecker.php
+++ b/src/PermissionChecker.php
@@ -15,7 +15,6 @@ use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
 use Contao\Database;
 use Contao\StringUtil;
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -98,7 +97,7 @@ class PermissionChecker implements FrameworkAwareInterface
             return [];
         }
 
-        $existingIds = $this->db->fetchFirstColumn('SELECT id FROM tl_news_category WHERE id IN (?)', [$rootIds], [ArrayParameterType::INTEGER]);
+        $existingIds = $this->db->fetchFirstColumn('SELECT id FROM tl_news_category WHERE id IN (?)', [$rootIds], [Connection::PARAM_INT_ARRAY]);
 
         if (empty($existingIds)) {
             return [];


### PR DESCRIPTION
`ArrayParameterType` does not exist yet in Doctrine `2.x`, thus the following error occurs:

```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError:
Attempted to load class "ArrayParameterType" from namespace "Doctrine\DBAL".
Did you forget a "use" statement for another namespace?

  at vendor/codefog/contao-news_categories/src/PermissionChecker.php:101
  at Codefog\NewsCategoriesBundle\PermissionChecker->getUserAllowedRoots()
     (vendor/codefog/contao-news_categories/src/EventListener/DataContainer/NewsCategoryListener.php:107)
  at Codefog\NewsCategoriesBundle\EventListener\DataContainer\NewsCategoryListener->onLoadCallback()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:197)
  at Contao\DC_Table->__construct()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:409)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:169)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:48)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:169)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:81)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web/index.php:31)
```

_Note:_ the change is still compatible with Doctrine `3.x` (albeit deprecated). Once you have switched the dependency to `doctrine/dbal: ^3.0` you can switch to `ArrayParameterType`.