### PR TITLE
Add missing use statements for `HtmlHeadBag`

### DIFF
--- a/src/FrontendModule/CumulativeFilterModule.php
+++ b/src/FrontendModule/CumulativeFilterModule.php
@@ -11,6 +11,7 @@
 namespace Codefog\NewsCategoriesBundle\FrontendModule;
 
 use Codefog\NewsCategoriesBundle\Model\NewsCategoryModel;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\FrontendTemplate;
 use Contao\StringUtil;
 use Contao\System;

--- a/src/FrontendModule/CumulativeHierarchicalFilterModule.php
+++ b/src/FrontendModule/CumulativeHierarchicalFilterModule.php
@@ -5,6 +5,7 @@ namespace Codefog\NewsCategoriesBundle\FrontendModule;
 
 
 use Codefog\NewsCategoriesBundle\Model\NewsCategoryModel;
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\Database;
 use Contao\FrontendTemplate;
 use Contao\Input;


### PR DESCRIPTION
Two modules are missing the appropriate use statements for the `HtmlHeadBag` class and thus the canonical URL is not set by these modules.