### PR TITLE
Track whether filtering was applied

### DIFF
--- a/src/Criteria/NewsCriteriaBuilder.php
+++ b/src/Criteria/NewsCriteriaBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Codefog\NewsCategoriesBundle\Criteria;
 
 use Codefog\HasteBundle\Model\DcaRelationsModel;
+use Codefog\NewsCategoriesBundle\Exception\CategoryFilteringNotAppliedException;
 use Codefog\NewsCategoriesBundle\Exception\CategoryNotFoundException;
 use Codefog\NewsCategoriesBundle\Exception\NoNewsException;
 use Codefog\NewsCategoriesBundle\FrontendModule\CumulativeFilterModule;
@@ -66,6 +67,8 @@ class NewsCriteriaBuilder
             $this->setRegularListCriteria($criteria, $module);
         } catch (NoNewsException) {
             return null;
+        } catch (CategoryFilteringNotAppliedException $e) {
+            // noop
         }
 
         return $criteria;
@@ -74,7 +77,7 @@ class NewsCriteriaBuilder
     /**
      * Get the criteria for list module.
      */
-    public function getCriteriaForListModule(array $archives, bool|null $featured, Module $module): NewsCriteria|null
+    public function getCriteriaForListModule(array $archives, bool|null $featured, Module $module, bool $throwOnFilteringNotApplied = false): NewsCriteria|null
     {
         $criteria = new NewsCriteria($this->framework, $this->tokenChecker);
 
@@ -91,10 +94,14 @@ class NewsCriteriaBuilder
                 $this->setRelatedListCriteria($criteria, $module);
             } else {
                 // Set the regular list criteria
-                $this->setRegularListCriteria($criteria, $module);
+                $this->setRegularListCriteria($criteria, $module, $throwOnFilteringNotApplied);
             }
         } catch (NoNewsException) {
             return null;
+        } catch (CategoryFilteringNotAppliedException $e) {
+            if ($throwOnFilteringNotApplied) {
+                throw $e;
+            }
         }
 
         return $criteria;
@@ -116,6 +123,8 @@ class NewsCriteriaBuilder
             $this->setRegularListCriteria($criteria, $module);
         } catch (NoNewsException) {
             return null;
+        } catch (CategoryFilteringNotAppliedException $e) {
+            // noop
         }
 
         return $criteria;
@@ -129,9 +138,12 @@ class NewsCriteriaBuilder
      */
     private function setRegularListCriteria(NewsCriteria $criteria, Module $module): void
     {
+        $filteringApplied = false;
+
         // Filter by default categories
         if (!empty($default = StringUtil::deserialize($module->news_filterDefault, true))) {
             $criteria->setDefaultCategories($default);
+            $filteringApplied = true;
         }
 
         // Filter by multiple active categories
@@ -165,13 +177,13 @@ class NewsCriteriaBuilder
                         }
                     }
                 }
+
+                $filteringApplied = true;
             }
-
-            return;
         }
-
         // Filter by active category
-        if ($module->news_filterCategories) {
+        elseif ($module->news_filterCategories) {
+            /** @var Input $input */
             $input = $this->framework->getAdapter(Input::class);
             $param = $this->manager->getParameterName();
 
@@ -184,7 +196,13 @@ class NewsCriteriaBuilder
                 }
 
                 $criteria->setCategory($category->id, (bool) $module->news_filterPreserve, (bool) $module->news_includeSubcategories);
+
+                $filteringApplied = true;
             }
+        }
+
+        if (!$filteringApplied) {
+            throw new CategoryFilteringNotAppliedException();
         }
     }
 

--- a/src/EventListener/NewsListener.php
+++ b/src/EventListener/NewsListener.php
@@ -14,6 +14,7 @@ namespace Codefog\NewsCategoriesBundle\EventListener;
 
 use Codefog\NewsCategoriesBundle\Criteria\NewsCriteria;
 use Codefog\NewsCategoriesBundle\Criteria\NewsCriteriaBuilder;
+use Codefog\NewsCategoriesBundle\Exception\CategoryFilteringNotAppliedException;
 use Codefog\NewsCategoriesBundle\Exception\CategoryNotFoundException;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\CoreBundle\Exception\PageNotFoundException;
@@ -30,8 +31,12 @@ class NewsListener
     #[AsHook('newsListCountItems')]
     public function onNewsListCountItems(array $archives, bool|null $featured, ModuleNewsList $module): int
     {
-        if (null === ($criteria = $this->getCriteria($archives, $featured, $module))) {
-            return 0;
+        try {
+            if (null === ($criteria = $this->getCriteria($archives, $featured, $module))) {
+                return 0;
+            }
+        } catch (CategoryFilteringNotAppliedException $e) {
+            return false;
         }
 
         return NewsModel::countBy($criteria->getColumns(), $criteria->getValues());
@@ -43,8 +48,12 @@ class NewsListener
     #[AsHook('newsListFetchItems')]
     public function onNewsListFetchItems(array $archives, bool|null $featured, int $limit, int $offset, ModuleNewsList $module): Collection|null
     {
-        if (null === ($criteria = $this->getCriteria($archives, $featured, $module))) {
-            return null;
+        try {
+            if (null === ($criteria = $this->getCriteria($archives, $featured, $module))) {
+                return null;
+            }
+        } catch (CategoryFilteringNotAppliedException $e) {
+            return false;
         }
 
         $criteria->setLimit($limit);
@@ -60,7 +69,7 @@ class NewsListener
     private function getCriteria(array $archives, bool|null $featured, ModuleNewsList $module): NewsCriteria|null
     {
         try {
-            $criteria = $this->searchBuilder->getCriteriaForListModule($archives, $featured, $module);
+            $criteria = $this->searchBuilder->getCriteriaForListModule($archives, $featured, $module, true);
         } catch (CategoryNotFoundException $e) {
             throw new PageNotFoundException($e->getMessage(), 0, $e);
         }

--- a/src/Exception/CategoryFilteringNotAppliedException.php
+++ b/src/Exception/CategoryFilteringNotAppliedException.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * News Categories bundle for Contao Open Source CMS.
+ *
+ * @copyright  Copyright (c) 2017, Codefog
+ * @author     Codefog <https://codefog.pl>
+ * @license    MIT
+ */
+
+namespace Codefog\NewsCategoriesBundle\Exception;
+
+class CategoryFilteringNotAppliedException extends \RuntimeException
+{
+}


### PR DESCRIPTION
Fix for #258 

This PR introduces a `CategoryFilteringNotAppliedException` in the `NewsCriteriaBuilder::setRegularListCriteria` method which will allow you to return `false` if desired in a `newsListFetchItems` or `newsListCountItems` hook. For backwards compatibility `NewsCriteriaBuilder::getCriteriaForListModule` will not throw this exception by default.