### PR TITLE
Fix service registration exclusions

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -8,4 +8,4 @@ services:
 
     Codefog\NewsCategoriesBundle\:
         resource: '../src'
-        exclude: '../../{ContentElement,FrontendModule,Model}'
+        exclude: '../src/{ContaoManager,DependencyInjection,ContentElement,Exception,FrontendModule,Model,CodefogNewsCategoriesBundle.php}'


### PR DESCRIPTION
This PR fixes the service registration exclusions - and adds more exclusions. This fixes errors like https://github.com/oveleon/contao-cookiebar/pull/236.