### PR TITLE
Fixed wrong reference in language files causing PHP Warning

### DIFF
--- a/contao/languages/de/tl_module.php
+++ b/contao/languages/de/tl_module.php
@@ -27,7 +27,7 @@ $GLOBALS['TL_LANG']['tl_module']['news_showEmptyCategories'] = ['Leere Kategorie
 $GLOBALS['TL_LANG']['tl_module']['news_forceCategoryUrl'] = ['Kategorie-URL erzwingen', 'Nutzt die Zielseite der Kategorie (falls gesetzt) statt die reguläre Filter-URL.'];
 $GLOBALS['TL_LANG']['tl_module']['news_categoriesRoot'] = ['Referenz-Kategorie (Root)', 'Hier kann die Referenzkategorie ausgewählt werden. Diese wird als Startpunkt benutzt (ähnlich zum Navigationsmodul).'];
 $GLOBALS['TL_LANG']['tl_module']['news_categoryFilterPage'] = ['Kategorie-Zielseite', 'Hier kann die Zielseite für die Kategorie-Filterung festgelegt werden. Dies überschreibt die Kategorie-Zielseite.'];
-$GLOBALS['TL_LANG']['tl_module']['news_categoryImgSize'] = ['Bildgröße für Nachrichten-Kategorien', &$GLOBALS['TL_LANG']['tl_module']['imgSize'][1]];
+$GLOBALS['TL_LANG']['tl_module']['news_categoryImgSize'] = ['Bildgröße für Nachrichten-Kategorien', &$GLOBALS['TL_LANG']['MSC']['imgSize'][1]];
 
 /*
  * Reference.

--- a/contao/languages/en/tl_module.php
+++ b/contao/languages/en/tl_module.php
@@ -27,7 +27,7 @@ $GLOBALS['TL_LANG']['tl_module']['news_showEmptyCategories'] = ['Show empty cate
 $GLOBALS['TL_LANG']['tl_module']['news_forceCategoryUrl'] = ['Force category URL', 'Use the category target page URL (if available) instead of the regular filter-link.'];
 $GLOBALS['TL_LANG']['tl_module']['news_categoriesRoot'] = ['Reference category (root)', 'Here you can choose the reference category. It will be used as the starting point (similar to navigation module).'];
 $GLOBALS['TL_LANG']['tl_module']['news_categoryFilterPage'] = ['Category target page', 'Here you can choose the news category target page that will override the category URLs with a filter-link to this page.'];
-$GLOBALS['TL_LANG']['tl_module']['news_categoryImgSize'] = ['News category image size', &$GLOBALS['TL_LANG']['tl_module']['imgSize'][1]];
+$GLOBALS['TL_LANG']['tl_module']['news_categoryImgSize'] = ['News category image size', &$GLOBALS['TL_LANG']['MSC']['imgSize'][1]];
 
 /*
  * Reference.


### PR DESCRIPTION
Fixes the PHP Warning that appears when editing a module with an image size field which label references to `MSC.imgSize` or `tl_module.imgSize`:
<img width="1061" height="343" alt="image" src="https://github.com/user-attachments/assets/dc305f89-19b1-4f08-a3c3-895ec74d7028" />
